### PR TITLE
Add failing spec

### DIFF
--- a/spec/words_in_numbers_spec.rb
+++ b/spec/words_in_numbers_spec.rb
@@ -69,6 +69,7 @@ describe WordsInNumbers do
     expect('nine thousand two hundred'.in_numbers).to eq(9200)
     expect('nine thousand two hundred and seven'.in_numbers).to eq(9207)
     expect('nine thousand two hundred and ninety seven'.in_numbers).to eq(9297)
+    expect('a thousand six hundred and fifty-five'.in_numbers).to eq(1655)
   end
 
   it 'should handle larger numbers' do


### PR DESCRIPTION
In testing, found that it got tripped-up by this one. Returns `1161`.